### PR TITLE
feat: provide a production ready docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-slim
+FROM node:18-slim AS build
 
 # Setting working directory.
 WORKDIR /opt/meilisearch-ui
@@ -11,7 +11,14 @@ COPY . .
 # Installing dependencies
 RUN pnpm install
 
-EXPOSE 24900
+# Build the app
+RUN npm run build
 
-# Running the app
-CMD ["pnpm", "run", "start"]
+# -------
+FROM nginx
+
+COPY --from=build /opt/meilisearch-ui/dist /usr/share/nginx/html
+
+RUN sed -i 's/80/24900/g' /etc/nginx/conf.d/default.conf
+
+EXPOSE 24900


### PR DESCRIPTION
Change dockerfile to build a production-ready static docker image.

There is no reason for a docker deployment to be running with the devkit. It's less efficient and needs almost 2GiB memory to deploy because of the building process.

The prebuilt docker image uses nginx as a static HTTP server. It only needs serval MiB memory.