### PR TITLE
Prevent 404 on page refresh by adding Nginx config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN npm run build
 FROM nginx
 
 COPY --from=build /opt/meilisearch-ui/dist /usr/share/nginx/html
-
-RUN sed -i 's/80/24900/g' /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/nginx.conf
 
 EXPOSE 24900

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,28 @@
+events { }
+http {
+
+  include mime.types;
+  sendfile on;
+
+  server {
+      listen        24900;
+      listen        [::]:24900;
+      server_name   localhost;
+
+      #error_page  404              /404.html;
+      root /usr/share/nginx/html;
+
+      # direct all traffic to index.html for client-side SPA routing
+      location / {
+        try_files $uri $uri/ /index.html;
+      }
+
+      # redirect server error pages to the static page /50x.html
+      #
+      error_page   500 502 503 504  /50x.html;
+      location = /50x.html {
+          root   /usr/share/nginx/html;
+      }
+  }
+
+}


### PR DESCRIPTION
Since the introduction of Nginx in #116, refreshing the page on a non-root URL will cause a 404 error to occur:

<img width="704" alt="Screenshot 2024-05-03 at 11 57 17" src="https://github.com/riccox/meilisearch-ui/assets/10178648/1c715395-538b-4b89-b811-54d70764cdd0">

This is because Nginx cannot match any URL other than /, since all routing is done client-side by `react-router-dom`.

This PR adds a custom Nginx configuration file, which routes all URIs to /index.html. This means the request can then be picked up by React's client-side routing from there.