### PR TITLE
fix swapped danger zone buttons

### DIFF
--- a/src/components/Settings/dangerZone.tsx
+++ b/src/components/Settings/dangerZone.tsx
@@ -77,7 +77,7 @@ export const DangerZone: FC<{
                 });
               }}
             >
-              {t('all_documents_delete.label')}
+              {t('index_delete.label')}
             </Button>
             <Button
               variant="solid"
@@ -102,7 +102,7 @@ export const DangerZone: FC<{
                 });
               }}
             >
-              {t('index_delete.label')}
+              {t('all_documents_delete.label')}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
Clicking on "Delete This Index" currently opens the "Delete All Documents" modal and vice versa.