### PR TITLE
fix: links of breadcrumbs do not respect BASE_URL

### DIFF
--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -46,7 +46,7 @@ export const DashBreadcrumb = () => {
 	return (
 		<Breadcrumbs color="primary" variant="light">
 			{!isSingletonMode() && (
-				<BreadcrumbItem href=`${baseUrl}`>
+				<BreadcrumbItem href={`${baseUrl}`}>
 					🏠
 				</BreadcrumbItem>
 			)}

--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -41,7 +41,7 @@ export const DashBreadcrumb = () => {
 		state.instances.find((i) => i.id === Number.parseInt(insRoute.insID)),
 	);
 
-	const baseUrl = import.meta.env.BASE_URL ?? "";
+	const baseUrl = import.meta.env.BASE_URL === "/" ? "" : (import.meta.env.BASE_URL ?? "");
 
 	return (
 		<Breadcrumbs color="primary" variant="light">

--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -41,12 +41,12 @@ export const DashBreadcrumb = () => {
 		state.instances.find((i) => i.id === Number.parseInt(insRoute.insID)),
 	);
 
-	const baseUrl = import.meta.env.BASE_URL ?? "/";
+	const baseUrl = import.meta.env.BASE_URL ?? "";
 
 	return (
 		<Breadcrumbs color="primary" variant="light">
 			{!isSingletonMode() && (
-				<BreadcrumbItem href={`${baseUrl}`}>
+				<BreadcrumbItem href={`${baseUrl || "/"}`}>
 					🏠
 				</BreadcrumbItem>
 			)}

--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -41,15 +41,17 @@ export const DashBreadcrumb = () => {
 		state.instances.find((i) => i.id === Number.parseInt(insRoute.insID)),
 	);
 
+	const baseUrl = import.meta.env.BASE_URL ?? "/";
+
 	return (
 		<Breadcrumbs color="primary" variant="light">
 			{!isSingletonMode() && (
-				<BreadcrumbItem href={import.meta.env.BASE_URL ?? "/"}>
+				<BreadcrumbItem href=`${baseUrl}`>
 					🏠
 				</BreadcrumbItem>
 			)}
 			{insRoute && (
-				<BreadcrumbItem href={`/ins/${insRoute.insID}`}>
+				<BreadcrumbItem href={`${baseUrl}/ins/${insRoute.insID}`}>
 					{isSingletonMode()
 						? "🏠"
 						: `#${insRoute.insID} ${t("common:instance")} ${currentInstance?.name}`}
@@ -57,32 +59,32 @@ export const DashBreadcrumb = () => {
 			)}
 			{insKeysRoute && (
 				<BreadcrumbItem
-					href={`/ins/${insRoute.insID}/keys`}
+					href={`${baseUrl}/ins/${insRoute.insID}/keys`}
 				>{`${t("common:keys")}`}</BreadcrumbItem>
 			)}
 			{insTasksRoute && (
 				<BreadcrumbItem
-					href={`/ins/${insRoute.insID}/tasks`}
+					href={`${baseUrl}/ins/${insRoute.insID}/tasks`}
 				>{`${t("common:tasks")}`}</BreadcrumbItem>
 			)}
 			{indexRoute && (
 				<BreadcrumbItem
-					href={`/ins/${insRoute.insID}/index/${indexRoute.indexUID}`}
+					href={`${baseUrl}/ins/${insRoute.insID}/index/${indexRoute.indexUID}`}
 				>{`${t("common:indexes")}: ${indexRoute.indexUID}`}</BreadcrumbItem>
 			)}
 			{indexDocsRoute && (
 				<BreadcrumbItem
-					href={`/ins/${insRoute.insID}/index/${indexRoute.indexUID}/documents`}
+					href={`${baseUrl}/ins/${insRoute.insID}/index/${indexRoute.indexUID}/documents`}
 				>{`${t("documents")}`}</BreadcrumbItem>
 			)}
 			{indexDocsUploadRoute && (
 				<BreadcrumbItem
-					href={`/ins/${insRoute.insID}/index/${indexRoute.indexUID}/documents/upload`}
+					href={`${baseUrl}/ins/${insRoute.insID}/index/${indexRoute.indexUID}/documents/upload`}
 				>{`${t("upload:title")}`}</BreadcrumbItem>
 			)}
 			{indexSettingRoute && (
 				<BreadcrumbItem
-					href={`/ins/${insRoute.insID}/index/${indexRoute.indexUID}/setting`}
+					href={`${baseUrl}/ins/${insRoute.insID}/index/${indexRoute.indexUID}/setting`}
 				>{`${t("settings")}`}</BreadcrumbItem>
 			)}
 		</Breadcrumbs>


### PR DESCRIPTION
I deployed both Meilisearch and `meilisearch-ui` on a single instance and with a `BASE_PATH` of `/ui/`.

I thought my webserver routing was incorrect after I experienced some 404s when I clicked on the breadcrumbs.
A closer look revealed that the links generated for the breadcrumbs are not correct.

This PR adds `BASE_URL` as a prefix to the `href` of the breadcrumbs.