### PR TITLE
feat(docker): Add dynamic BASE_PATH support to lite image (#245)

### DIFF
--- a/Dockerfile-lite
+++ b/Dockerfile-lite
@@ -15,9 +15,22 @@ RUN pnpm install
 RUN npm run build
 
 # -------
-FROM nginx
+FROM nginx:stable-alpine AS final
 
 COPY --from=build /opt/meilisearch-ui/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/nginx.conf
 
+# Create a directory for our available templates
+RUN mkdir -p /etc/nginx/templates-available/
+
+# Copy in the templates and the entrypoint scripts
+COPY nginx.basepath.conf.template /etc/nginx/templates-available/
+COPY nginx.root.conf.template /etc/nginx/templates-available/
+COPY docker-entrypoint.d/15-prepare-templates.sh /docker-entrypoint.d/
+COPY docker-entrypoint.d/30-basepath-subst.sh /docker-entrypoint.d/
+
+# Make the scripts executable
+RUN chmod +x /docker-entrypoint.d/15-prepare-templates.sh /docker-entrypoint.d/30-basepath-subst.sh
+
+# Default to root
+ENV BASE_PATH=""
 EXPOSE 24900

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ For specific image variants, please refer to [Image version list](https://hub.do
 
 lite images do not support the following features:
 
-- Custom path
 - Singleton mode
 
 ### Deploy on Vercel
@@ -108,9 +107,7 @@ For example, if you want to deploy this app to the `/meilisearch-ui` path, you c
 docker run -d --restart=on-failure:5 --name="meilisearch-ui" -p <your-port>:24900 -e BASE_PATH="/meilisearch-ui" riccoxie/meilisearch-ui:latest
 ```
 
-> [!WARNING]
->
-> Please note that if you want to use a custom base path to the function, please use the full version image instead of the `lite` variant image. Please refer to [this issue](https://github.com/riccox/meilisearch-ui/issues/178) for details.
+
 
 ### Singleton mode
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -82,7 +82,6 @@ docker run -d --restart=on-failure:5 --name="meilisearch-ui" -p <your-port>:2490
 
 lite 镜像不支持以下功能：
 
-- 自定义路径
 - 单实例模式
 
 ### 使用 Vercel 部署
@@ -107,9 +106,7 @@ lite 镜像不支持以下功能：
 docker run -d --restart=on-failure:5 --name="meilisearch-ui" -p <your-port>:24900 -e BASE_PATH="/meilisearch-ui" riccoxie/meilisearch-ui:latest
 ```
 
-> [!WARNING]
->
-> 请注意，如果你要使用自定义基础路径到功能，请使用完整版镜像，而不要使用`lite`变体镜像，具体请参考[问题](https://github.com/riccox/meilisearch-ui/issues/178).
+
 
 ### 单实例模式 Singleton mode
 

--- a/docker-entrypoint.d/15-prepare-templates.sh
+++ b/docker-entrypoint.d/15-prepare-templates.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+# This script prepares the correct nginx template based on BASE_PATH.
+
+TEMPLATE_DIR="/etc/nginx/templates"
+AVAILABLE_DIR="/etc/nginx/templates-available"
+DEST_TEMPLATE="$TEMPLATE_DIR/default.conf.template"
+
+mkdir -p "$TEMPLATE_DIR"
+
+if [ -n "$BASE_PATH" ]; then
+  # Use the template that supports a base path
+  cp "$AVAILABLE_DIR/nginx.basepath.conf.template" "$DEST_TEMPLATE"
+else
+  # Use the simpler template for serving from the root
+  cp "$AVAILABLE_DIR/nginx.root.conf.template" "$DEST_TEMPLATE"
+fi
+
+exit 0

--- a/docker-entrypoint.d/30-basepath-subst.sh
+++ b/docker-entrypoint.d/30-basepath-subst.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+# This script performs base path substitution in static assets.
+
+# Sanitize BASE_PATH and define replacement patterns
+if [ -n "$BASE_PATH" ]; then
+  REPLACE_PATH=$(echo "$BASE_PATH" | sed 's:/*$::' | sed 's:^/*::')
+  FINAL_REPLACE_PATH="${REPLACE_PATH}/"
+else
+  FINAL_REPLACE_PATH=""
+fi
+
+# Replace the placeholder in the built files
+find /usr/share/nginx/html -type f \( -name "*.js" -o -name "*.css" -o -name "*.html" \) -exec \
+  sed -i -e "s|MEILI_UI_REPLACE_BASE_PATH/|${FINAL_REPLACE_PATH}|g" \
+         -e "s|MEILI_UI_REPLACE_BASE_PATH|${FINAL_REPLACE_PATH%/}|g" {} + 
+
+exit 0

--- a/index.html
+++ b/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="shortcut icon" type="image/x-icon" href="/meili-logo.svg" />
+    <link rel="shortcut icon" type="image/x-icon" href="meili-logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Meilisearch UI</title>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="src/main.tsx"></script>
   </body>
 </html>

--- a/nginx.basepath.conf.template
+++ b/nginx.basepath.conf.template
@@ -1,0 +1,25 @@
+server {
+    listen 24900;
+    listen [::]:24900;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+
+    # Add trailing slash to BASE_PATH if it's missing
+    rewrite ^${BASE_PATH}$ ${BASE_PATH}/ permanent;
+
+    location ${BASE_PATH}/ {
+      alias /usr/share/nginx/html/;
+      try_files $uri $uri/ /index.html;
+    }
+
+    # Redirect from root to BASE_PATH
+    location = / {
+        return 302 http://$http_host${BASE_PATH}/;
+    }
+
+    error_page 500 502 503 504 /50x.html;
+    location = /50x.html {
+      root /usr/share/nginx/html;
+    }
+  }

--- a/nginx.root.conf.template
+++ b/nginx.root.conf.template
@@ -1,11 +1,4 @@
-events {
-}
-http {
-
-  include mime.types;
-  sendfile on;
-
-  server {
+server {
     listen 24900;
     listen [::]:24900;
     server_name localhost;
@@ -25,5 +18,3 @@ http {
       root /usr/share/nginx/html;
     }
   }
-
-}

--- a/scripts/cmd.sh
+++ b/scripts/cmd.sh
@@ -16,8 +16,11 @@ if [ ! -z "$SINGLETON_MODE" ]; then
   fi
 fi
 
-if [ ! -z "$BASE_PATH" ]; then
+export BASE_PATH="${BASE_PATH:-/}"
+
+if [ "$BASE_PATH" != "/" ]; then
   echo "Custom base path: $BASE_PATH"
 fi
+
 pnpm run build
 pnpm run preview

--- a/src/components/common/Breadcrumb.tsx
+++ b/src/components/common/Breadcrumb.tsx
@@ -41,8 +41,7 @@ export const DashBreadcrumb = () => {
 		state.instances.find((i) => i.id === Number.parseInt(insRoute.insID)),
 	);
 
-	const baseUrl =
-		import.meta.env.BASE_URL === "/" ? "" : (import.meta.env.BASE_URL ?? "");
+	const baseUrl = (import.meta.env.BASE_URL ?? "").replace(/\/$/, "");
 
 	return (
 		<Breadcrumbs color="primary" variant="light">

--- a/src/hooks/useCurrentInstance.ts
+++ b/src/hooks/useCurrentInstance.ts
@@ -28,11 +28,8 @@ export const useCurrentInstance = () => {
 		console.debug("useCurrentInstance", "Singleton Instance lost");
 		setWarningPageData({ prompt: t("instance:singleton_cfg_not_found") });
 		// do not use useNavigate, because maybe in first render
-		if (import.meta.env.BASE_URL !== "/") {
-			window.location.assign(`${import.meta.env.BASE_URL || ""}/warning`);
-		} else {
-			window.location.assign("/warning");
-		}
+		const baseUrl = (import.meta.env.BASE_URL ?? "").replace(/\/$/, "");
+		window.location.assign(`${baseUrl}/warning`);
 	}
 	return currentInstance as Instance;
 };

--- a/src/hooks/useMeiliClient.ts
+++ b/src/hooks/useMeiliClient.ts
@@ -29,11 +29,8 @@ export const useMeiliClient = () => {
 			} else {
 				setWarningPageData({ prompt: t("instance:singleton_cfg_not_found") });
 				// do not use useNavigate, because maybe in first render
-				if (import.meta.env.BASE_URL !== "/") {
-					window.location.assign(`${import.meta.env.BASE_URL || ""}/warning`);
-				} else {
-					window.location.assign("/warning");
-				}
+				const baseUrl = (import.meta.env.BASE_URL ?? "").replace(/\/$/, "");
+				window.location.assign(`${baseUrl}/warning`);
 			}
 			return;
 		}
@@ -50,11 +47,8 @@ export const useMeiliClient = () => {
 			} else {
 				setWarningPageData({ prompt: t("instance:singleton_cfg_not_found") });
 				// do not use useNavigate, because maybe in first render
-				if (import.meta.env.BASE_URL !== "/") {
-					window.location.assign(`${import.meta.env.BASE_URL || ""}/warning`);
-				} else {
-					window.location.assign("/warning");
-				}
+				const baseUrl = (import.meta.env.BASE_URL ?? "").replace(/\/$/, "");
+				window.location.assign(`${baseUrl}/warning`);
 			}
 		}
 	}, [currentInstance, setWarningPageData, t]);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig(({ mode }) => {
 	const env = loadEnv(mode, process.cwd(), "");
 	env.BASE_PATH && console.debug("Using custom base path:", env.BASE_PATH);
 	return {
-		base: env.BASE_PATH || "/",
+		base: env.BASE_PATH || 'MEILI_UI_REPLACE_BASE_PATH',
 		plugins: [
 			tsconfigPaths({ root: "./" }),
 			react(),


### PR DESCRIPTION
* Make lite container compatible with BASE_PATH env.

* refactor: simplify basepath template logic

* fix: default base path for default Dockerfile

* refactor: hook into supported nginx docker entrypoint scripts

* docs: update README to account for base path support in lite image

* fix: broken breadcrumb links

* fix(routing): Correctly handle base URL for redirects

Corrects an issue where `window.location.assign` calls in `useCurrentInstance.ts` and `useMeiliClient.ts` could generate malformed URLs, specifically leading to double slashes (e.g., `//warning`) or incorrect paths when the application was served from a subpath.

The problem stemmed from an incorrect assumption about the format of `import.meta.env.BASE_URL` and its concatenation with relative paths.